### PR TITLE
Switch to a flat deploy structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ node_modules/
 *.swp
 *.pid
 alan
-home/pkg/
+home/*.json
+home/*.wasm
+home/*.ts
 *.js

--- a/build.sh
+++ b/build.sh
@@ -10,5 +10,5 @@ cargo install wasm-pack
 yarn wasm-compiler
 popd
 cp alan/alanStdBundle.js home/alanStdBundle.js
-cp -r alan/web_compiler/pkg home/pkg
+cp -r alan/web_compiler/pkg/* home/
 rm -rf alan

--- a/home/index.html
+++ b/home/index.html
@@ -8,7 +8,7 @@
     <script type="importmap">
       {
         "imports": {
-          "web_compiler": "./pkg/web_compiler.js",
+          "web_compiler": "./web_compiler.js",
           "alan_std": "./alanStdBundle.js"
         }
       }


### PR DESCRIPTION
This supposedly is not necessary, but the actual deploy script seems to be ignoring the pkg directory, so here we go.
